### PR TITLE
Use replace instead of conflict for sensio/distribution-bundle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "symfony/process": "~2.3|~3.0|^4.0",
         "sensiolabs/security-checker": "~3.0|~4.0"
     },
-    "conflict": {
+    "replace": {
         "sensio/distribution-bundle": "*"
     },
     "autoload": {


### PR DESCRIPTION
Right now, if some libraries/bundles require `sensio/distribution-bundle` 5.x, they cannot be installed with `sylius/sylius`, due to this conflict.

This is the case with integration of eZ Platform and Sylius for example.